### PR TITLE
Define noop speex_assert when building with OUTSIDE_SPEEX defined

### DIFF
--- a/libspeexdsp/resample.c
+++ b/libspeexdsp/resample.c
@@ -63,6 +63,7 @@
 
 #ifdef OUTSIDE_SPEEX
 #include <stdlib.h>
+#define speex_assert(cond)
 static void *speex_alloc (int size) {return calloc(size,1);}
 static void *speex_realloc (void *ptr, int size) {return realloc(ptr, size);}
 static void speex_free (void *ptr) {free(ptr);}


### PR DESCRIPTION
The file won't build otherwise and there is no good way to define this kind of macro on the command line. 