### PR TITLE
Resample.c: drop unused variable

### DIFF
--- a/libspeexdsp/resample.c
+++ b/libspeexdsp/resample.c
@@ -798,7 +798,6 @@ EXPORT SpeexResamplerState *speex_resampler_init(spx_uint32_t nb_channels, spx_u
 
 EXPORT SpeexResamplerState *speex_resampler_init_frac(spx_uint32_t nb_channels, spx_uint32_t ratio_num, spx_uint32_t ratio_den, spx_uint32_t in_rate, spx_uint32_t out_rate, int quality, int *err)
 {
-   spx_uint32_t i;
    SpeexResamplerState *st;
    int filter_err;
 


### PR DESCRIPTION
Minor fix to delete a single unused variable