### PR TITLE
Fix a stack smashing bug

### DIFF
--- a/libspeexdsp/buffer.c
+++ b/libspeexdsp/buffer.c
@@ -135,7 +135,7 @@ EXPORT int speex_buffer_read(SpeexBuffer *st, void *_data, int len)
    char *data = _data;
    if (len > st->available)
    {
-      SPEEX_MEMSET(data+st->available, 0, st->size-st->available);
+      SPEEX_MEMSET(data+st->available, 0, len - st->available);
       len = st->available;
    }
    end = st->read_ptr + len;


### PR DESCRIPTION
If we have less than requested, the difference between that and available should be used.