### PR TITLE
Ignore the m4 folder created by autogen.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ libtool
 speexdsp.pc
 stamp-*
 patches
+/m4


### PR DESCRIPTION
When I run

    ./autogen.sh

in a fresh Git checkout, it shows the "m4" folder as changed. This happens with autoconf 2.69, but I'm sure it also happens with other versions.

Add the "m4" folder to the `.gitignore` file, so that the working tree appears as clean.