### PR TITLE
Make JitterBufferPacket user_data a pointer sized field

### DIFF
--- a/include/speex/speex_jitter.h
+++ b/include/speex/speex_jitter.h
@@ -63,7 +63,7 @@ struct _JitterBufferPacket {
    spx_uint32_t timestamp;  /**< Timestamp for the packet */
    spx_uint32_t span;       /**< Time covered by the packet (same units as timestamp) */
    spx_uint16_t sequence;   /**< RTP Sequence number if available (0 otherwise) */
-   spx_uint32_t user_data;  /**< Put whatever data you like here (it's ignored by the jitter buffer) */
+   uintptr_t user_data;  /**< Put whatever data you like here (it's ignored by the jitter buffer) */
 };
 
 /** Packet has been retrieved */


### PR DESCRIPTION
Make JitterBufferPacket.user_data a pointer sized field so that in 64 bits it can contain a pointer if required.