### PR TITLE
Fix incorrect macro names in arch.h

### DIFF
--- a/libspeexdsp/arch.h
+++ b/libspeexdsp/arch.h
@@ -44,7 +44,7 @@
 #ifdef USE_SSE
 #error SSE is only for floating-point
 #endif
-#if ((defined (ARM4_ASM)||defined (ARM4_ASM)) && defined(BFIN_ASM)) || (defined (ARM4_ASM)&&defined(ARM5E_ASM))
+#if defined(ARM4_ASM) + defined(ARM5E_ASM) + defined(BFIN_ASM) > 1
 #error Make up your mind. What CPU do you have?
 #endif
 #ifdef VORBIS_PSYCHO
@@ -56,10 +56,10 @@
 #ifndef FLOATING_POINT
 #error You now need to define either FIXED_POINT or FLOATING_POINT
 #endif
-#if defined (ARM4_ASM) || defined(ARM5E_ASM) || defined(BFIN_ASM)
+#if defined(ARM4_ASM) || defined(ARM5E_ASM) || defined(BFIN_ASM)
 #error I suppose you can have a [ARM4/ARM5E/Blackfin] that has float instructions?
 #endif
-#ifdef FIXED_POINT_DEBUG
+#ifdef FIXED_DEBUG
 #error "Don't you think enabling fixed-point is a good thing to do if you want to debug that?"
 #endif
 
@@ -117,9 +117,9 @@ typedef spx_word32_t spx_sig_t;
 
 #ifdef ARM5E_ASM
 #include "fixed_arm5e.h"
-#elif defined (ARM4_ASM)
+#elif defined(ARM4_ASM)
 #include "fixed_arm4.h"
-#elif defined (BFIN_ASM)
+#elif defined(BFIN_ASM)
 #include "fixed_bfin.h"
 #endif
 
@@ -210,7 +210,7 @@ typedef float spx_word32_t;
 #endif
 
 
-#if defined (CONFIG_TI_C54X) || defined (CONFIG_TI_C55X)
+#if defined(CONFIG_TI_C54X) || defined(CONFIG_TI_C55X)
 
 /* 2 on TI C5x DSP */
 #define BYTES_PER_CHAR 2


### PR DESCRIPTION
I found what appears to be a few typos in `libspeexdsp/arch.h` in the option combination tests.

* One check looks for `FIXED_POINT_DEBUG`, but this is the only time a macro by this name is ever used in the project (or in libspeex). This seems like it was meant to be `FIXED_DEBUG` based on the error message, so I changed it.

* The check for the ARM optimization macros has `(defined (ARM4_ASM)||defined (ARM4_ASM))`, which is redundant. Based on the context, I assume this was meant to be `(defined (ARM4_ASM)||defined (ARM5E_ASM))`. I ended up replacing the entire check with a simpler version that utilizes the fact that the sum of boolean comparisons is the count of true values.

* There were a few cases of inconsistent whitespace usage in this file. In the other files in the project, `defined()` did not have a space before the parenthesis, but spaces were inconsistently added in this file. I went ahead and removed all these spaces to make the file consistent with the rest of the project.

There was something else I was unable to figure out what was going on with. There are a few instances of the macos `CONFIG_TI_C54X`, `CONFIG_TI_C55X`, and `CONFIG_TI_C6X` in the project, but not in the configuration. The `configure.ac` file does have an option that defines the macro `TI_C55X`, but this macro isn't used anywhere in the project (or in libspeex). I'm not sure what's going on here, so I've left it alone, but this probably needs to be looked into.