### PR TITLE
Remove trailing white space from COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
 Copyright 2002-2008 	Xiph.org Foundation
 Copyright 2002-2008 	Jean-Marc Valin
 Copyright 2005-2007	Analog Devices Inc.
-Copyright 2005-2008	Commonwealth Scientific and Industrial Research 
+Copyright 2005-2008	Commonwealth Scientific and Industrial Research
                         Organisation (CSIRO)
 Copyright 1993, 2002, 2006 David Rowe
 Copyright 2003 		EpicGames


### PR DESCRIPTION
This is an extremely trivial change that removes a single trailing white space from the `COPYING` file.  I am doing this because speexdsp is a common vendored dependency in downstream projects which presumably have a copy of this file and it would be nice to have this removed at the source to stop propagating it elsewhere.