### PR TITLE
libspeexdsp.def: add .dll extension to def file

### DIFF
--- a/win32/libspeexdsp.def
+++ b/win32/libspeexdsp.def
@@ -1,4 +1,4 @@
-LIBRARY libspeexdsp
+LIBRARY libspeexdsp.dll
 EXPORTS
 
 


### PR DESCRIPTION
MSVC doesn't completely respect this line but MinGW does. Specify the name properly.