### PR TITLE
Resolve build error C2065: 'M_PI': undeclared identifier` (fix issue #49)

### DIFF
--- a/libspeexdsp/testresample2.c
+++ b/libspeexdsp/testresample2.c
@@ -30,13 +30,15 @@
    POSSIBILITY OF SUCH DAMAGE.
 */
 
+#define _USE_MATH_DEFINES
+#include <math.h>
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 
 #include "speex/speex_resampler.h"
 #include <stdio.h>
-#include <math.h>
 #include <stdlib.h>
 
 #define PERIOD 32


### PR DESCRIPTION
Refer to issue #49 

This is subject to maintainer choosing another way
cc @tmatth 