### PR TITLE
multiply_frac wrong overflow

### DIFF
--- a/libspeexdsp/resample.c
+++ b/libspeexdsp/resample.c
@@ -594,11 +594,17 @@ static int multiply_frac(spx_uint32_t *result, spx_uint32_t value, spx_uint32_t 
 {
    spx_uint32_t major = value / den;
    spx_uint32_t remain = value % den;
-   /* TODO: Could use 64 bits operation to check for overflow. But only guaranteed in C99+ */
+#if __STDC_VERSION__ >= 199901L
+   uint64_t r = (uint64_t)remain * (uint64_t)num / (uint64_t)den + (uint64_t)major * (uint64_t)num;
+   if (r > UINT32_MAX)
+      return RESAMPLER_ERR_OVERFLOW;
+   *result = (spx_uint32_t)r;
+#else
    if (remain > UINT32_MAX / num || major > UINT32_MAX / num
        || major * num > UINT32_MAX - remain * num / den)
       return RESAMPLER_ERR_OVERFLOW;
    *result = remain * num / den + major * num;
+#endif
    return RESAMPLER_ERR_SUCCESS;
 }
 


### PR DESCRIPTION
I'm doing an asrc. I have problem because `multiply_frac` wrongly go in overflow.

My case is
in rate: 48000
out rate: 48000
num_rate: 500733
den_rate: 500000
num/den = 1.001466

and for example my samp_frac_num is 173475.

then I set
num_rate: 199999 
den_rate: 1000000
num/den = 0.199999

this is a big change in ratio, but is done only to test.

When I do this change, I get overflow in multiply_frac function.

remain = 173475 > UINT32_MAX / 1000000  and this go in overflow.

but if I do all the operation with 64bit is ok
remain * num / den + major * num = 173475 * 199999 / 1000000 + 0 * 199999 = 34694 and this is correct.

the 2nd problem is that if multiply_frac fails wile I'm calling `speex_resampler_set_rate_frac`
the internal variable is left wrangly updated, and this create more problems later with possible access to invalid memory.

